### PR TITLE
Fix bombard; must be installed after siege

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ RUN apt-get update && apt-get install -qq -y \
 	libssl-dev \
 	git
 RUN wget --no-verbose  http://www.cpan.org/authors/id/C/CH/CHARTGRP/Chart-2.4.6.tar.gz && tar zxf Chart-2.4.6.tar.gz && cd Chart-2.4.6 && perl Makefile.PL && make && make test && make install
-RUN git clone https://github.com/allardhoeve/bombard.git && cd bombard && ./configure && make && make install
 RUN cd .. && git clone https://github.com/JoeDog/siege.git && cd siege && utils/bootstrap && ./configure && make && make install
+
+# Siege must be installed before bombard, as bombard determines siege's path at build time
+RUN git clone https://github.com/allardhoeve/bombard.git && cd bombard && ./configure && make && make install
 
 COPY .siegerc /root/.siegerc


### PR DESCRIPTION
See this line from (debianized) bombard source:

https://github.com/allardhoeve/bombard/blob/1f750b15c637b0adaae0583e3ef3be2b137d69be/src/bombard.in#L27

I was trying to use this docker image and it wasn't running siege. I couldn't figure out why. When I looked at bombard's code inside the container, I saw that line saying `my $siege = "false ";`. Changing the install order fixed it.
